### PR TITLE
bug (windows): diplicated items in list of available generators

### DIFF
--- a/bin/slush.js
+++ b/bin/slush.js
@@ -185,7 +185,11 @@ function getModulesPaths () {
   }
   paths.push(path.join(__dirname, '..', '..'));
   paths.push.apply(paths, require.main.paths);
-  return paths;
+  return paths.map(function(path){
+    return path.toLowerCase();
+  }).filter(function(path, index, all){
+    return all.lastIndexOf(path) === index;
+  });
 }
 
 function findGenerators (searchpaths) {


### PR DESCRIPTION
On Windows, when I called `slush --help` I saw something like this

``` bash
[slush] Installed generators
[slush] ├── angular (0.3.3)
[slush] ├── coffee (0.1.0)
[slush] ├── angular (0.3.3)
[slush] ├── coffee (0.1.0)
[slush] ├── angular (0.3.3)
[slush] └── coffee (0.1.0)
```

It happens because `getModulesPaths` generate array with duplicated paths and they need to be filtered. 
