### PR TITLE
Add support for scoped npm modules

### DIFF
--- a/bin/slush.js
+++ b/bin/slush.js
@@ -177,12 +177,19 @@ function getModulesPaths () {
   if (process.env.NODE_ENV === 'test') {
     return [path.join(__dirname, '..', 'test')];
   }
+  var sep = (process.platform === 'win32') ? ';' : ':';
   var paths = [];
-  if (process.platform === 'win32') {
-    paths.push(path.join(process.env.APPDATA, 'npm', 'node_modules'));
+
+  if (process.env.NODE_PATH) {
+    paths = paths.concat(process.env.NODE_PATH.split(sep));
   } else {
-    paths.push('/usr/lib/node_modules');
+    if (process.platform === 'win32') {
+      paths.push(path.join(process.env.APPDATA, 'npm', 'node_modules'));
+    } else {
+      paths.push('/usr/lib/node_modules');
+    }
   }
+
   paths.push(path.join(__dirname, '..', '..'));
   paths.push.apply(paths, require.main.paths);
   return paths.map(function(path){

--- a/bin/slush.js
+++ b/bin/slush.js
@@ -199,8 +199,8 @@ function getModulesPaths () {
 
 function findGenerators (searchpaths) {
   return searchpaths.reduce(function (arr, searchpath) {
-    return arr.concat(glob.sync('slush-*', {cwd: searchpath, stat: true}).map(function (match) {
-      var generator = {path: path.join(searchpath, match), name: match.slice(6), pkg: {}};
+    return arr.concat(glob.sync('{@*/,}slush-*', {cwd: searchpath, stat: true}).map(function (match) {
+      var generator = {path: path.join(searchpath, match), name: match.replace(/(?:@[\w]+[\/|\\]+)?slush-/, ""), pkg: {}};
       try {
         generator.pkg = require(path.join(searchpath, match, 'package.json'));
       } catch (e) {

--- a/bin/slush.js
+++ b/bin/slush.js
@@ -192,9 +192,7 @@ function getModulesPaths () {
 
   paths.push(path.join(__dirname, '..', '..'));
   paths.push.apply(paths, require.main.paths);
-  return paths.map(function(path){
-    return path.toLowerCase();
-  }).filter(function(path, index, all){
+  return paths.filter(function(path, index, all){
     return all.lastIndexOf(path) === index;
   });
 }

--- a/test/slush.js
+++ b/test/slush.js
@@ -25,8 +25,8 @@ describe('slush', function () {
     });
     slush.on('close', function (code) {
       code.should.equal(0);
-      data.should.match(/\[gulp\] ├── default/);
-      data.should.match(/\[gulp\] └── app/);
+      data.should.match(/├── default/);
+      data.should.match(/└── app/);
       done();
     });
   });


### PR DESCRIPTION
Hello,

- This pull request introduces support for [scoped npm modules](https://www.npmjs.com/enterprise#scoped). We currently have a need for this in my organization. Nutshell: Slush is now able to find modules like `@company/slush-foo`.
- I have also added the ability to detect paths via `process.env.NODE_PATH` in an effort to avoid hard-coded paths.
- I've also stopped converting paths to lower case, to address #17.
- Lastly, I've fixed a failing test (it was failing before my edits).

I'd love to see this land soon! Let me know if you have issues / questions / concerns.