### PR TITLE
Add 'slush .' cli command to execute local slushfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ All `slush-*` packages should be installed globally (for now) to be found by the
    - add `slushgenerator` as package keyword
    - create a slushfile.js
    - Install `gulp` and used gulp plugins for your generator as ordinary dependencies
+* You can test your slush generator by running `slush .` in your slush generator's directory.
 
 ### Slush uses gulp
 

--- a/bin/slush.js
+++ b/bin/slush.js
@@ -173,7 +173,7 @@ function getGenerator (name) {
 }
 
 function getLocalGenerator (name) {
-  var fullpath = proess.cwd();
+  var fullpath = process.cwd();
   var generator = {
       path: fullpath, 
       name: fullpath.split('/').pop().split('\\').pop(), 

--- a/bin/slush.js
+++ b/bin/slush.js
@@ -164,9 +164,25 @@ function logEvents(name, gulpInst) {
 }
 
 function getGenerator (name) {
+  if (name === '.') {
+    return getLocalGenerator();
+  }
   return getAllGenerators().filter(function (gen) {
     return gen.name === name;
   })[0];
+}
+
+function getLocalGenerator (name) {
+  var fullpath = proess.cwd();
+  var generator = {
+      path: fullpath, 
+      name: fullpath.split('/').pop().split('\\').pop(), 
+      pkg: {}
+      };
+      try {
+        generator.pkg = require(path.join(fullpath.cwd(), 'package.json'));
+      } catch (e) { }
+    return generator;
 }
 
 function getAllGenerators () {


### PR DESCRIPTION
When "slush ." is run from a folder slush will now try to execute the slushfile from that folder. This makes it easier to test new slush generators that are still in development. (Resolves #43)
