### PR TITLE
Drop dependency on deprecated `gulp-util`

### DIFF
--- a/bin/slush.js
+++ b/bin/slush.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 'use strict';
-var gutil = require('gulp-util');
+var fancyLog = require('fancy-log');
 var prettyTime = require('pretty-hrtime');
 var glob = require('glob');
 var path = require('path');
@@ -47,11 +47,11 @@ var cli = new Liftoff({
 });
 
 cli.on('require', function(name) {
-  gutil.log('Requiring external module', chalk.magenta(name));
+  fancyLog('Requiring external module', chalk.magenta(name));
 });
 
 cli.on('requireFail', function(name) {
-  gutil.log(chalk.red('Failed to load external module'), chalk.magenta(name));
+  fancyLog(chalk.red('Failed to load external module'), chalk.magenta(name));
 });
 
 cli.launch(handleArguments, argv);
@@ -67,7 +67,7 @@ function handleArguments(env) {
   if (versionFlag) {
     log(slushPackage.version);
     if (env.modulePackage) {
-      gutil.log(env.modulePackage.version);
+      fancyLog(env.modulePackage.version);
     }
     if (generator.pkg.version) {
       console.log('[' + chalk.green('slush-' + generator.name) + '] ' + generator.pkg.version);
@@ -76,7 +76,7 @@ function handleArguments(env) {
   }
 
   if (!env.modulePath) {
-    gutil.log(chalk.red('No local gulp install found in'), chalk.magenta(generator.path));
+    fancyLog(chalk.red('No local gulp install found in'), chalk.magenta(generator.path));
     log(chalk.red('This is an issue with the `slush-' + generator.name + '` generator'));
     process.exit(1);
   }
@@ -96,7 +96,7 @@ function handleArguments(env) {
 
   if (process.cwd() !== env.cwd) {
     process.chdir(env.cwd);
-    gutil.log('Working directory changed to', chalk.magenta(env.cwd));
+    fancyLog('Working directory changed to', chalk.magenta(env.cwd));
   }
 
   process.nextTick(function() {
@@ -125,7 +125,7 @@ function logTasks(name, localGulp) {
   tree.label = 'Tasks for generator ' + chalk.magenta(name);
   archy(tree).split('\n').forEach(function(v) {
     if (v.trim().length === 0) return;
-    gutil.log(v);
+    fancyLog(v);
   });
 }
 
@@ -139,18 +139,18 @@ function formatError(e) {
 // wire up logging events
 function logEvents(name, gulpInst) {
   gulpInst.on('task_start', function(e) {
-    gutil.log('Starting', "'" + chalk.cyan(name + ':' + e.task) + "'...");
+    fancyLog('Starting', "'" + chalk.cyan(name + ':' + e.task) + "'...");
   });
 
   gulpInst.on('task_stop', function(e) {
     var time = prettyTime(e.hrDuration);
-    gutil.log('Finished', "'" + chalk.cyan(name + ':' + e.task) + "'", 'after', chalk.magenta(time));
+    fancyLog('Finished', "'" + chalk.cyan(name + ':' + e.task) + "'", 'after', chalk.magenta(time));
   });
 
   gulpInst.on('task_err', function(e) {
     var msg = formatError(e);
     var time = prettyTime(e.hrDuration);
-    gutil.log("'" + chalk.cyan(name + ':' + e.task) + "'", 'errored after', chalk.magenta(time), chalk.red(msg));
+    fancyLog("'" + chalk.cyan(name + ':' + e.task) + "'", 'errored after', chalk.magenta(time), chalk.red(msg));
   });
 
   gulpInst.on('task_not_found', function(err) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,21 +1,21 @@
 'use strict';
 
 var gulp = require('gulp');
-var log = require('gulp-util').log;
+var fancyLog = require('fancy-log');
 
 var jshint = require('gulp-jshint');
 
 var codeFiles = ['**/*.js', '!node_modules/**'];
 
 gulp.task('lint', function() {
-  log('Linting Files');
+  fancyLog('Linting Files');
   return gulp.src(codeFiles)
     .pipe(jshint('.jshintrc'))
     .pipe(jshint.reporter());
 });
 
 gulp.task('watch', function() {
-  log('Watching Files');
+  fancyLog('Watching Files');
   gulp.watch(codeFiles, ['lint']);
 });
 

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "slush": "./bin/slush.js"
   },
   "dependencies": {
-    "glob": "~4.0.0",
-    "minimist": "~0.1.0",
-    "gulp-util": "^2.2.0",
-    "pretty-hrtime": "^0.2.0",
     "archy": "^0.0.2",
+    "chalk": "^0.4.0",
+    "fancy-log": "^1.3.2",
+    "glob": "~4.0.0",
     "liftoff": "~0.10.0",
-    "chalk": "^0.4.0"
+    "minimist": "~0.1.0",
+    "pretty-hrtime": "^0.2.0"
   },
   "devDependencies": {
     "mocha": "^1.17.0",


### PR DESCRIPTION
Closes slushjs/slush#61